### PR TITLE
Correction to the z-axis rotation function

### DIFF
--- a/mplstereonet/stereonet_math.py
+++ b/mplstereonet/stereonet_math.py
@@ -101,8 +101,8 @@ def _rotate_y(x, y, z, theta):
     return X, Y, Z
 
 def _rotate_z(x, y, z, theta):
-    X = y*np.cos(theta) + x*np.sin(theta)
-    Y = -y*np.sin(theta) + x*np.cos(theta)
+    X = x*np.cos(theta) + -y*np.sin(theta)
+    Y = x*np.sin(theta) + y*np.cos(theta)
     Z = z
     return X, Y, Z
 


### PR DESCRIPTION
I think that the current z-axis rotation function has switched the x and y columns of the transformation matrix, resulting in a 0° rotation returning a vector 90° to the original vector.

I was also thinking that it would be a good idea to write a test for the 3 rotation functions, but I didn't have the time yet to learn how to work with pytest.