### PR TITLE
Handle subplot subclassing correctly in newer versions of MPL

### DIFF
--- a/mplstereonet/stereonet_axes.py
+++ b/mplstereonet/stereonet_axes.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib.transforms import Affine2D
 from matplotlib.projections import register_projection, LambertAxes
-from matplotlib.axes import Axes
+from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.ticker import NullLocator, FixedLocator
 
 import matplotlib.path as mpath
@@ -827,6 +827,13 @@ class EqualAreaAxes(StereonetAxes):
     """An axes representing a lower-hemisphere "Schmitt" (a.k.a. equal area)
     projection."""
     name = 'equal_area_stereonet'
+
+# We need to define explict subplot classes so that we don't mess up the
+# method resolution order when using matplotlib subplots.
+EqualAngleAxesSubplot = subplot_class_factory(EqualAngleAxes)
+EqualAngleAxesSubplot.__module__ = EqualAngleAxes.__module__
+EqualAreaAxesSubplot = subplot_class_factory(EqualAngleAxes)
+EqualAreaAxesSubplot.__module__ = EqualAngleAxes.__module__
 
 register_projection(StereonetAxes)
 register_projection(EqualAreaAxes)


### PR DESCRIPTION
Currently, `StereonetAxes` doesn't work correctly when used with subplots (e.g. `mplstereonet.subplots` or using the `projection` kwarg when constructing a subplot).  This is because `mplstereonet` is missing a step in subclasses `Axes`. As a result, calls to methods that have been overridden find the original axes methods instead.

This leads to errors similar to:

```
$ python polar_overlay.py 
Traceback (most recent call last):
  File "polar_overlay.py", line 38, in <module>
    main()
  File "polar_overlay.py", line 13, in main
    ax1.grid(kind='polar')
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/axes/_base.py", line 2738, in grid
    self.xaxis.grid(b, which=which, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/axis.py", line 1453, in grid
    **gridkw)
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/axis.py", line 856, in set_tick_params
    kwtrans = self._translate_tick_kw(kw, to_init_kw=True)
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/axis.py", line 921, in _translate_tick_kw
    % (key, kwkeys))
ValueError: keyword grid_kind is not recognized; valid keywords are [u'size', u'width', u'color', u'tickdir', u'pad', u'labelsize', u'labelcolor', u'zorder', u'gridOn', u'tick1On', u'tick2On', u'label1On', u'label2On', u'length', u'direction', u'left', u'bottom', u'right', u'top', u'labelleft', u'labelbottom', u'labelright', u'labeltop', u'labelrotation', u'grid_agg_filter', u'grid_alpha', u'grid_animated', u'grid_antialiased', u'grid_clip_box', u'grid_clip_on', u'grid_clip_path', u'grid_color', u'grid_contains', u'grid_dash_capstyle', u'grid_dash_joinstyle', u'grid_dashes', u'grid_drawstyle', u'grid_figure', u'grid_fillstyle', u'grid_gid', u'grid_label', u'grid_linestyle', u'grid_linewidth', u'grid_marker', u'grid_markeredgecolor', u'grid_markeredgewidth', u'grid_markerfacecolor', u'grid_markerfacecoloralt', u'grid_markersize', u'grid_markevery', u'grid_path_effects', u'grid_picker', u'grid_pickradius', u'grid_rasterized', u'grid_sketch_params', u'grid_snap', u'grid_solid_capstyle', u'grid_solid_joinstyle', u'grid_transform', u'grid_url', u'grid_visible', u'grid_xdata', u'grid_ydata', u'grid_zorder', u'grid_c', u'grid_mfc', u'grid_ms', u'grid_mew', u'grid_aa', u'grid_mfcalt', u'grid_mec', u'grid_lw', u'grid_ls']
```