### PR TITLE
Fix incorrect assumptions in stereonet_math tests

### DIFF
--- a/tests/examples.py
+++ b/tests/examples.py
@@ -47,7 +47,7 @@ def make_pil_image(fig):
     """Make a PIL image object from a matplotlib figure instance."""
     fig.canvas.draw()
     size = fig.canvas.get_width_height()
-    im = Image.fromstring('RGB', size, fig.canvas.tostring_rgb())
+    im = Image.frombytes('RGB', size, fig.canvas.tostring_rgb())
     return im
 
 def run(example_filename):

--- a/tests/test_stereonet_math.py
+++ b/tests/test_stereonet_math.py
@@ -210,10 +210,10 @@ class TestAngularDistance:
     def test_directional(self):
         first, second = smath.line(30, 270), smath.line(40, 90)
         dist = smath.angular_distance(first, second, bidirectional=True)
-        assert np.allclose(dist, 70)
+        assert np.allclose(dist, np.radians(70))
 
         dist = smath.angular_distance(first, second, bidirectional=False)
-        assert np.allclose(dist, 110)
+        assert np.allclose(dist, np.radians(110))
 
 def compare_lonlat(lon1, lat1, lon2, lat2):
     """Avoid ambiguities in strike/dip or lon/lat conventions."""

--- a/tests/test_stereonet_math.py
+++ b/tests/test_stereonet_math.py
@@ -192,7 +192,7 @@ class TestAngularDistance:
             for lat in range(-90, 100, 10):
                 point1 = np.radians([lon, lat])
                 point2 = smath.antipode(*point1)
-                dist = smath.angular_distance(point1, point2)
+                dist = smath.angular_distance(point1, point2, False)
                 msg = 'Failed at {}, {}'.format(lon, lat)
                 assert np.allclose(dist, np.pi), msg
     


### PR DESCRIPTION
`stereonet_math` tests were not updated when `angular_distance` changed to include a `bidirectional` option.

Basically, the test updates made in https://github.com/joferkington/mplstereonet/commit/bed783a53c9992a9949d62c0b7138aabb5ff65ba were incorrect and weren't properly run.