### PR TITLE
Skip interpolation for paths that request no interpolation

### DIFF
--- a/mplstereonet/stereonet_transforms.py
+++ b/mplstereonet/stereonet_transforms.py
@@ -25,7 +25,11 @@ class BaseStereonetTransform(Transform):
         # This will interpolate grid lines but leave more complex paths (e.g.
         # contours) alone. If we don't do this, we'll have problems with
         # contourf and other plotting functions. There should be a better way...
-        if len(path.vertices) == 2:
+        # We also need to skip interpolating paths that explicitly ask to not
+        # be interpolated (e.g. a Line2D path with 2 points)
+        if path._interpolation_steps == 1:
+            ipath = path
+        elif len(path.vertices) == 2:
             ipath = path.interpolated(self._resolution)
         else:
             ipath = path


### PR DESCRIPTION
At some point `Line2D` instances started drawing markers for interpolated vertices as well as original vertices.  With matplotlib 3.0, this leads to issues similar to:

```
import matplotlib.pyplot as plt
import mplstereonet

fig, ax = mplstereonet.subplots()
ax.pole([315, 120], [40, 20], 'bo')
plt.show()
```

![wrong_points](https://user-images.githubusercontent.com/906803/47690219-2fac7a00-dbbb-11e8-8971-f184664f0a93.png)

With this PR applied, we'd get the expected result:
![correct_two_points](https://user-images.githubusercontent.com/906803/47690339-b19ca300-dbbb-11e8-890d-4285cf3200bb.png)

We've always interpolated the paths, so previously the interpolated points were just hidden. The key change that made this start showing up appears to be that `Line2D` instances are rendered with markers at every interpolated vertex instead of every interpolated vertex.

Note that this same issue currently exists for all core matplotlib Hammer/Molleweide/etc geo axes, as well.  I should get a PR/issue into core matplotlib to update the various geo axes examples.