### PR TITLE
Resolve depreciation, change np.float64 to float

### DIFF
--- a/mplstereonet/contouring.py
+++ b/mplstereonet/contouring.py
@@ -14,7 +14,7 @@ def _count_points(lons, lats, func, sigma, gridsize=(100,100), weights=None):
     if weights is None:
         weights = 1
     # Normalize the weights
-    weights = np.asarray(weights, dtype=np.float64)
+    weights = np.asarray(weights, dtype=float)
     weights /= weights.mean()
 
     # Generate a regular grid of "counters" to measure on...
@@ -31,7 +31,7 @@ def _count_points(lons, lats, func, sigma, gridsize=(100,100), weights=None):
     # Basically, we can't model this as a convolution as we're not in cartesian
     # space, so we have to iterate through and call the kernel function at
     # each "counter".
-    totals = np.zeros(xyz_counters.shape[0], dtype=np.float64)
+    totals = np.zeros(xyz_counters.shape[0], dtype=float)
     for i, xyz in enumerate(xyz_counters):
         cos_dist = np.abs(np.dot(xyz, xyz_points.T))
         density, scale = func(cos_dist, sigma)

--- a/mplstereonet/stereonet_math.py
+++ b/mplstereonet/stereonet_math.py
@@ -157,7 +157,7 @@ def plane(strike, dip, segments=100, center=(0, 0)):
     """
     lon0, lat0 = center
     strikes, dips = np.atleast_1d(strike, dip)
-    lons = np.zeros((segments, strikes.size), dtype=np.float64)
+    lons = np.zeros((segments, strikes.size), dtype=float)
     lats = lons.copy()
     for i, (strike, dip) in enumerate(zip(strikes, dips)):
         # We just plot a line of constant longitude and rotate it by the strike.


### PR DESCRIPTION
This PR addresses #50 by changing np.float64 to float, as suggested by the Numpy release documentation https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations . 